### PR TITLE
update mapnik version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "queue-async": "1.0.7",
     "sphericalmercator": "1.0.x",
-    "mapnik": "~3.2.0"
+    "mapnik": "^3.3.0"
   },
   "devDependencies":{
     "mocha": "1.x"


### PR DESCRIPTION
currently abaculus fails to install on iojs 2.0.0 due to mapnik 3.2 not installing and it not being able to use version 3.3