### PR TITLE
io.js compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 
 node_js:
   - "0.10"
-  - "0.11.14"
+  - "0.12"
+  - "iojs"
 
 before_install:
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "queue-async": "1.0.7",
     "sphericalmercator": "1.0.x",
-    "mapnik": "^3.3.0"
+    "mapnik": "~3.3.0"
   },
   "devDependencies":{
     "mocha": "1.x"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.1.1",
   "description": "stitches map tiles together for high-res exporting from tm2",
   "main": "index.js",
-  "engines": {
-    "node": "~0.10.x"
-  },
   "scripts": {
     "test": "mocha -R spec"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "queue-async": "1.0.7",
     "sphericalmercator": "1.0.x",
-    "mapnik": "~3.2.0"
+    "mapnik": "^3.3.0"
   },
   "devDependencies":{
     "mocha": "1.x"


### PR DESCRIPTION
This updates Travis' build targets to include node-0.12 and iojs-stable and upgrades Mapnik to 3.3.0.

Replaces #14 