### PR TITLE
Fix tilesize calculation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+# v3.0.1
+
+* Publishing under kartotherian namespace
+* Fixing tile size calculation for scales greater then 1
+
 # v3.0.0
 
 * Updates to mapnik 3.7.0

--- a/index.js
+++ b/index.js
@@ -78,8 +78,8 @@ abaculus.tileList = function(z, s, center, tileSize) {
     var ts = Math.floor(size * s);
 
     var centerCoordinate = {
-        column: x / size,
-        row: y / size,
+        column: x / ts,
+        row: y / ts,
         zoom: z
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@mapbox/abaculus",
-  "version": "3.0.0",
+  "name": "@kartotherian/abaculus",
+  "version": "3.0.1",
   "description": "stitches map tiles together for high-res exporting from tm2",
   "main": "index.js",
   "contributors": [

--- a/test/test.js
+++ b/test/test.js
@@ -88,19 +88,19 @@ describe('create list of tile coordinates', function() {
     it('should return a tiles object with correct coords', function() {
         var zoom = 5,
             scale = 4,
-            width = 1824,
-            height = 1832,
-            center = { x: 4096, y: 4096, w: width, h: height };
+            width = 250,
+            height = 250,
+            center = printer.coordsFromCenter(zoom, scale, { x: -47.368, y: -24.405, w: width, h: height }, limit, 256);
 
         var expectedCoords = {
             tiles: [
-                { z: zoom, x: 15, y: 15, px: -112, py: -108 },
-                { z: zoom, x: 15, y: 16, px: -112, py: 916 },
-                { z: zoom, x: 16, y: 15, px: 912, py: -108 },
-                { z: zoom, x: 16, y: 16, px: 912, py: 916 }
+                { z: zoom, x: 11, y: 17, px: -308, py: -768 },
+                { z: zoom, x: 11, y: 18, px: -308, py: 256 },
+                { z: zoom, x: 12, y: 17, px: 716, py: -768 },
+                { z: zoom, x: 12, y: 18, px: 716, py: 256 }
             ],
-            dimensions: { x: width, y: height },
-            center: { row: 16, column: 16, zoom: zoom },
+            dimensions: { x: Math.round(width*scale), y: Math.round(height*scale) },
+            center: { row: 18, column: 11, zoom: zoom },
             scale: scale
         };
         var coords = printer.tileList(zoom, scale, center);


### PR DESCRIPTION
The way it is calculated makes abaculus work only for scale = 1.

Also, changing the test case with an example easier to check and to reflect the new calculations.

The inputs are the same as the following:
https://maps.wikimedia.org/img/osm-intl,5,-24.405,-47.368,250x250.png

The tile outputs are the following:
https://maps.wikimedia.org/osm-intl/5/11/17.png
https://maps.wikimedia.org/osm-intl/5/12/17.png
https://maps.wikimedia.org/osm-intl/5/11/18.png
https://maps.wikimedia.org/osm-intl/5/12/18.png