### PR TITLE
Consider tilesize when calculating the grid

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# v3.1.1
+
+Fixes a bug when calculating the center for sizes > 1
+
 # v3.1.0
 
 * Update mocha to 6.x

--- a/index.js
+++ b/index.js
@@ -78,8 +78,8 @@ abaculus.tileList = function(z, s, center, tileSize) {
     var ts = Math.floor(size * s);
 
     var centerCoordinate = {
-        column: x / size,
-        row: y / size,
+        column: x / ts,
+        row: y / ts,
         zoom: z
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/abaculus",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/abaculus",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "stitches map tiles together for high-res exporting from tm2",
   "main": "index.js",
   "contributors": [

--- a/test/test.js
+++ b/test/test.js
@@ -88,19 +88,25 @@ describe('create list of tile coordinates', function() {
     it('should return a tiles object with correct coords', function() {
         var zoom = 5,
             scale = 4,
-            width = 1824,
-            height = 1832,
-            center = { x: 4096, y: 4096, w: width, h: height };
+            width = 250,
+            height = 250,
+            center = printer.coordsFromCenter(
+                zoom,
+                scale,
+                { x: -47.368, y: -24.405, w: width, h: height },
+                limit,
+                256
+            );
 
         var expectedCoords = {
             tiles: [
-                { z: zoom, x: 15, y: 15, px: -112, py: -108 },
-                { z: zoom, x: 15, y: 16, px: -112, py: 916 },
-                { z: zoom, x: 16, y: 15, px: 912, py: -108 },
-                { z: zoom, x: 16, y: 16, px: 912, py: 916 }
+                { z: zoom, x: 11, y: 17, px: -308, py: -768 },
+                { z: zoom, x: 11, y: 18, px: -308, py: 256 },
+                { z: zoom, x: 12, y: 17, px: 716, py: -768 },
+                { z: zoom, x: 12, y: 18, px: 716, py: 256 }
             ],
-            dimensions: { x: width, y: height },
-            center: { row: 16, column: 16, zoom: zoom },
+            dimensions: { x: width * scale, y: height * scale },
+            center: { row: 18, column: 11, zoom: zoom },
             scale: scale
         };
         var coords = printer.tileList(zoom, scale, center);


### PR DESCRIPTION
This never worked before. The calculation for sizes other than 1 did use the right center point for the static image.

The patch fixes that and also adjusts the test for it.

The code is currently used in a different fork that's deployed on the servers used here:

https://maps.wikimedia.org/img/osm-intl,18,43.748,7.434,400x400.png
https://maps.wikimedia.org/img/osm-intl,18,43.748,7.434,400x400@2x.png

`@2x` zooms the stitched tiles.

There's also an older pull request that's a bit outdated now. https://github.com/mapbox/abaculus/pull/39